### PR TITLE
Seed git config from local machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,6 +64,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     host_ip: '127.0.0.1', host: 8000,
     auto_correct: true
 
-  config.vm.provision "shell", inline: $script
+  config.vm.provision "gitconfig", type: "file",
+    source: "~/.gitconfig",
+    destination: ".gitconfig"
+
+  if File.exists?('~/.gitignore_global')
+    config.vm.provision "gitignores", type: "file",
+      source: "~/.gitignore_global",
+      destination: ".gitignore_global"
+  end
+
+  config.vm.provision "kickstart", type: "shell",
+    inline: $script
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,7 +74,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       destination: ".gitignore_global"
   end
 
-  config.vm.provision "kickstart", type: "shell",
-    inline: $script
+  config.vm.provision "shell", inline: $script
 
 end


### PR DESCRIPTION
This one is for @RamonB, @gfellerleonard and @amritb :dancers: :dancer: :dancers: :trollface: 

After this is merged the vagrant box will get seeded with a copy of your local ~/.gitconfig.

While I don't recommend using the internal git-client directly, this still eases the pain of using it considerably.

I've no idea if it works with the os that shall not be named, so someone should check that before merging...

## todos

* [x] test Unix based operating systems
* [ ] test windows
* [ ] fix this so it works with windows