### PR TITLE
customize virtualbox and make Vagrantfile configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+Vagrantfile.local

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ You may add a ``Vagrantfile.local`` file that overrides some defaults.
 The following example shows all configurable aspects of the system.
 
 ```ruby
-ipAddr = "192.168.50.20"
+Box::Config::ipAddr = "192.168.50.20"          #Default: null
+Box::Config::syncDirHost = "/path/to/project"  #Default: ENV['HOME']
+Box::Config::syncDirGuest = "/path/to/project" #Default: /home/vagrant
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "fernandezvara/centos7"
 
+  config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :type => 'nfs', :nfs_version => 4, :nfs_udp => false, :mount_options => ['nolock']
 
   if ipAddr.nil?
@@ -63,6 +64,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     guest: 8000,
     host_ip: '127.0.0.1', host: 8000,
     auto_correct: true
+
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    v.memory = 1024
+  end
 
   config.vm.provision "shell", inline: $script
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,8 +50,13 @@ SCRIPT
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "fernandezvara/centos7"
+  
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    v.memory = 2048
+  end
 
-  config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :type => 'nfs', :nfs_version => 4, :nfs_udp => false, :mount_options => ['nolock']
 
   if ipAddr.nil?
@@ -64,12 +69,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     guest: 8000,
     host_ip: '127.0.0.1', host: 8000,
     auto_correct: true
-
-  config.vm.provider "virtualbox" do |v|
-    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-    v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
-    v.memory = 1024
-  end
 
   config.vm.provision "shell", inline: $script
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,14 @@
 VAGRANTFILE_API_VERSION = "2"
 
-ipAddr = nil
+module Box
+  module Config
+    attr_accessor :ipAddr, :syncDirHost, :syncDirGuest
+    module_function :ipAddr, :ipAddr=, :syncDirHost, :syncDirHost=, :syncDirGuest, :syncDirGuest=
+    # set defaults
+    @syncDirHost = ENV['HOME']
+    @syncDirGuest = "/home/vagrant"
+  end
+end
 
 if File.exists?('Vagrantfile.local')
   load 'Vagrantfile.local'
@@ -57,12 +65,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.memory = 2048
   end
 
-  config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :type => 'nfs', :nfs_version => 4, :nfs_udp => false, :mount_options => ['nolock']
+  config.vm.synced_folder Box::Config::syncDirHost, Box::Config::syncDirGuest, id: "home", :type => 'nfs', :nfs_version => 4, :nfs_udp => false, :mount_options => ['nolock']
 
-  if ipAddr.nil?
+  if Box::Config::ipAddr.nil?
     config.vm.network "private_network", type: "dhcp"
   else
-    config.vm.network :private_network, ip: ipAddr
+    config.vm.network :private_network, ip: Box::Config::ipAddr
   end
 
   config.vm.network "forwarded_port",


### PR DESCRIPTION
add a new config block to customize the virtual machine.
* I think 512mb is insufficient.
* The other two configs makes sence, if you run the machine for a lengthy period of time. [Virtualbox](https://www.virtualbox.org/manual/ch09.html#nat-adv-dns)

make Vagrantfile configurable through Vagrantfile.local