### PR TITLE
Add support for the GravitonRabbitMqBundle

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ $script = <<SCRIPT
 yum -y install epel-release scl-utils deltarpm && \
 yum -y install https://www.softwarecollections.org/en/scls/rhscl/php55/epel-7-x86_64/download/rhscl-php55-epel-7-x86_64.noarch.rpm && \
 yum -y update && \
-yum -y install php55 php55-php-mongo php55-php-pdo php55-php-devel mongodb mongodb-server git && \
+yum -y install php55 php55-php-mongo php55-php-pdo php55-php-devel php55-php-bcmath php55-php-mbstring mongodb mongodb-server git && \
 sed -i -e 's/bind_ip = 127.0.0.1/#bind_ip = 127.0.0.1/g' /etc/mongod.conf && \
 systemctl enable mongod && \
 systemctl start mongod && \


### PR DESCRIPTION
Since the GravitonRabbitMqBundle ("GravitonMessageBundle") has been implemented (pull request: https://github.com/libgraviton/graviton/pull/251), Graviton depends on oldsound/rabbitmq-bundle and videlalvaro/php-amqplib. This requires the PHP extensions bcmath and mbstring to be installed.

This pull requests ensures the automatic installation of these extensions.