### PR TITLE
Add some documentation and Windows compatibility, fix some RabbitMQ issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@ want to configure your vagrant instance.
 vagrant plugin install vagrant-vbguest
 ```
 
+On Windows you should also install [winNFSd](https://github.com/winnfsd/vagrant-winnfsd):
+
+```bash
+vagrant plugin install vagrant-winnfsd
+```
+
 ### Versions
 - vagrant version >= 1.7
 - vagrant plugin 'vagrant-vbguest' (latest)
+- vagrant plugin 'vagrant-winnfsd' (latest, on Windows only)
 
 ## Initial Deploy
 
@@ -48,3 +55,13 @@ vagrant up
 You may add a ``Vagrantfile.local`` file that overrides some defaults.
 
 See [Vagrantfile.local.dist](Vagrantfile.local.dist) for an example config.
+
+
+## Default Ports
+The following services are available under the defined host ports:
+| Service                                 | Port  | Notes                  |
+|:----------------------------------------|:-----:|:-----------------------|
+| **Graviton**                            | 8000  |                        |
+| **MongoDB**                             | 27017 |                        |
+| **RabbitMQ**                            | 5672  |                        |
+| **RabbitMQ Management (Web Interface)** | 15672 | Login with guest:guest |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ See [Vagrantfile.local.dist](Vagrantfile.local.dist) for an example config.
 
 ## Default Ports
 The following services are available under the defined host ports:
+
 | Service                                 | Port  | Notes                  |
 |:----------------------------------------|:-----:|:-----------------------|
 | **Graviton**                            | 8000  |                        |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,10 +45,13 @@ ln -s vagrant-centos-7-php-wrapper.sh /usr/local/bin/phpunit && \
 su -l vagrant -c 'composer global require squizlabs/php_codesniffer' && \
 ln -s vagrant-centos-7-php-wrapper.sh /usr/local/bin/phpcs && \
 ln -s vagrant-centos-7-php-wrapper.sh /usr/local/bin/phpcbf && \
+systemctl enable rabbitmq-server && \
+systemctl start rabbitmq-server && \
 rabbitmq-plugins enable rabbitmq_management && \
 firewall-cmd --zone=public --add-port=8000/tcp --permanent && \
 firewall-cmd --zone=public --add-port=27017/tcp --permanent && \
 firewall-cmd --zone=public --add-port=5672/tcp --permanent && \
+firewall-cmd --zone=public --add-port=15672/tcp --permanent && \
 firewall-cmd --reload
 SCRIPT
 
@@ -62,7 +65,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.memory = 2048
   end
 
-  config.vm.synced_folder Box::Config::syncDirHost, Box::Config::syncDirGuest, id: "home", :type => 'nfs', :nfs_version => 4, :nfs_udp => false, :mount_options => ['nolock']
+  if Vagrant::Util::Platform.windows?
+     config.vm.synced_folder Box::Config::syncDirHost, Box::Config::syncDirGuest, id: "home", :type => 'nfs', :nfs_version => 3, :nfs_udp => true, :mount_options => ['nolock,vers=3,udp']
+  else
+    config.vm.synced_folder Box::Config::syncDirHost, Box::Config::syncDirGuest, id: "home", :type => 'nfs', :nfs_version => 4, :nfs_udp => false, :mount_options => ['nolock']
+  end
 
   if Box::Config::ipAddr.nil?
     config.vm.network "private_network", type: "dhcp"


### PR DESCRIPTION
Some member of the new feature team work on windows. This PR ensures that they can use NFS shares as well. It adds also some useful documentation for gravity-platform newcomers.
Moreover, this PR creates a firewall rule for the RabbitMQ Management plugin and ensures that RabbitMQ gets automatically started at `vagrant up`.